### PR TITLE
SketchDeck MockMVC Controller Tests

### DIFF
--- a/src/main/java/org/wecancodeit/sketchflex/controllers/SketchDeckController.java
+++ b/src/main/java/org/wecancodeit/sketchflex/controllers/SketchDeckController.java
@@ -6,6 +6,7 @@ import javax.annotation.Resource;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.wecancodeit.sketchflex.models.SketchDeck;
 import org.wecancodeit.sketchflex.repositories.SketchDeckRepository;
@@ -17,22 +18,26 @@ public class SketchDeckController {
 	@Resource
 	SketchDeckRepository sketchDeckRepo;
 
-	public String findOneSketchDeck(Long id, Model model) throws SketchDeckNotFoundException{
+	
+	@RequestMapping("/sketchdeck")
+	public String findOneSketchDeck(@RequestParam(value = "id")Long id, Model model) throws SketchDeckNotFoundException{
 	        Optional<SketchDeck> sketchDeck = sketchDeckRepo.findById(id);
 			
 			if(sketchDeck.isPresent()){
 				model.addAttribute("single-sketchdeck", sketchDeck.get());
+				// model.addAttribute("all-sketches",sketchDeck.get().getSketches());
 				
-				return "";
+				return "single-sketchdeck-template";
 			}
 			throw new SketchDeckNotFoundException();
 	}
-
+    
+	@RequestMapping("/sketchdecks")
 	public String findAllSketches(Model model) {
 		
 		model.addAttribute("all-sketchdecks",sketchDeckRepo.findAll());
 		
-		return "";	
+		return "all-sketchdecks-template";	
 	}
 
 }

--- a/src/main/java/org/wecancodeit/sketchflex/models/SketchDeck.java
+++ b/src/main/java/org/wecancodeit/sketchflex/models/SketchDeck.java
@@ -66,5 +66,6 @@ public class SketchDeck {
 			return false;
 		return true;
 	}
+	
 
 }

--- a/src/main/resources/templates/all-sketchdecks-template.html
+++ b/src/main/resources/templates/all-sketchdecks-template.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/main/resources/templates/single-sketchdeck-template.html
+++ b/src/main/resources/templates/single-sketchdeck-template.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/test/java/org/wecancodeit/sketchflex/controllers/SketchDeckControllerMockMVCTest.java
+++ b/src/test/java/org/wecancodeit/sketchflex/controllers/SketchDeckControllerMockMVCTest.java
@@ -1,0 +1,104 @@
+package org.wecancodeit.sketchflex.controllers;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.wecancodeit.sketchflex.models.SketchDeck;
+import org.wecancodeit.sketchflex.repositories.SketchDeckRepository;
+import org.wecancodeit.sketchflex.storage.StorageService;
+import org.wecancodeit.sketchflex.controllers.SketchDeckController;
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(SketchDeckController.class)
+public class SketchDeckControllerMockMVCTest {
+ 
+	
+  @Resource
+  private MockMvc mvc;
+  
+  @Mock
+  private SketchDeck sketchDeck1;
+  
+  @Mock
+  private SketchDeck sketchDeck2;
+	
+  @MockBean
+  private SketchDeckRepository sketchDeckRepo;
+  
+  @MockBean  //Tests failed without this even though it's not being tested...do not delete
+  private StorageService storageService;
+  
+  @Test 
+  public void shouldBeOkayForSingleSketchDeck() throws Exception
+  {
+   long id = 1;
+   when(sketchDeckRepo.findById(id)).thenReturn(Optional.of(sketchDeck1));
+   
+   mvc.perform(get("/sketchdeck?id=1")).andExpect(status().isOk());
+  }
+  
+  @Test 
+  public void shouldNotBeOkayForSingleSketchDeck() throws Exception
+  {
+	mvc.perform(get("/sketchdeck?id=1")).andExpect(status().isNotFound());  
+  }
+  
+  @Test
+  public void shouldRouteToSingleSketchDeckView() throws Exception
+  {
+   long id = 1;
+   when(sketchDeckRepo.findById(id)).thenReturn(Optional.of(sketchDeck1));
+   
+   mvc.perform(get("/sketchdeck?id=1")).andExpect(view().name("single-sketchdeck-template"));
+  }
+  
+  @Test
+  public void shouldAddSingleSketchDeckToModel() throws Exception
+  {
+   long id = 1;
+   when(sketchDeckRepo.findById(id)).thenReturn(Optional.of(sketchDeck1));
+   
+   mvc.perform(get("/sketchdeck?id=1")).andExpect(model().attribute("single-sketchdeck",sketchDeck1));
+  }
+  
+  @Test
+  public void shouldBeOkayForAllSketches() throws Exception
+  {
+   mvc.perform(get("/sketchdecks")).andExpect(status().isOk());
+  }
+  
+  @Test
+  public void shouldRouteToAllSketchesView() throws Exception
+  {
+   mvc.perform(get("/sketchdecks")).andExpect(view().name("all-sketchdecks-template"));
+  }
+  
+  @Test
+  public void shouldAddAllSketchDecksIntoModel() throws Exception
+  {
+   Collection<SketchDeck> allSketchDecks = Arrays.asList(sketchDeck1,sketchDeck2); 
+   when(sketchDeckRepo.findAll()).thenReturn(allSketchDecks);
+	  
+   mvc.perform(get("/sketchdecks")).andExpect(model().attribute("all-sketchdecks",allSketchDecks));
+  }
+  
+  
+  
+}


### PR DESCRIPTION
SketchDeckControllerMVCTests (shouldBeOkayForOneSketchDeck,shouldNotBeOkayForOneSketchDeck, shouldBeOkayForAllSketchDecks, shouldRouteToSingleSketchDeckView,shouldRouteToAllSketchDeckView, shouldAddOneSketchDeckIntoModel,shouldAddAllSketchDecksIntoModel) to drive creation of Single-Sketch-Template (bare-bones), and All-Sketches-Template(bare-bones), and the addition of  the appropriate return line,mappings,and parameters to the SketchDeckController methods findSingleSketchDeck and findAllSketchDecks.