### PR TITLE
all sketches view links to single sketch view

### DIFF
--- a/src/main/java/org/wecancodeit/sketchflex/controllers/FileUploadController.java
+++ b/src/main/java/org/wecancodeit/sketchflex/controllers/FileUploadController.java
@@ -76,6 +76,9 @@ public class FileUploadController {
 		String imageLocation = "/images/" + file.getOriginalFilename();
 		SketchDeck sketchDeck = sketchDeckRepo.findByNameContainingIgnoreCase(sketchDeckName);
 		if (sketchDeck == null) {
+			if(sketchDeckName.equals("")) {
+				sketchDeckName = "none";
+			}
 			sketchDeck = new SketchDeck(sketchDeckName);
 			sketchDeckRepo.save(sketchDeck);
 		}

--- a/src/main/resources/templates/all-sketches-template.html
+++ b/src/main/resources/templates/all-sketches-template.html
@@ -5,10 +5,12 @@
 <title>Sketches</title>
 </head>
 <body>
+	<h1>Sketches</h1>
 	<ul>
-		<li th:each="sketch : ${sketches}"><a th:text="${sketch.name}"></a>
-			<a>SketchDeck: </a><a th:text="${sketch.sketchDeck.name}"></a> <img
-			th:src="@{${sketch.imageLocation}}"></li>
+		<li th:each="sketch : ${sketches}">
+			<a th:text="${sketch.name}"></a>
+			<h3 th:text="${'SketchDeck: ' + sketch.sketchDeck.name}"></h3> 
+			<a th:href= "@{/sketch(id=${sketch.id})}"><img th:src="@{${sketch.imageLocation}}"></a></li>
 	</ul>
 </body>
 </html>

--- a/src/main/resources/templates/sketch-view-template.html
+++ b/src/main/resources/templates/sketch-view-template.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
 <meta charset="ISO-8859-1">
-<title>Insert title here</title>
+<title th:text="${sketch.name}"></title>
 </head>
 <body>
-
+	<h1 th:text="${sketch.name}"></h1>
+	<h3 th:text="${'SketchDeck: ' + sketch.sketchDeck.name}"></h3>
+	<img th:src="@{${sketch.imageLocation}}">
+	
 </body>
 </html>


### PR DESCRIPTION
Name of sketchDeck is displayed on sketches. If no sketchDeck name is entered on upload, default value is "none". The images on /sketches will link to individual sketch pages. 