### PR TITLE
Removed the Logo Goes Here from the single-sketch-template.html

### DIFF
--- a/src/main/resources/templates/single-sketch-template.html
+++ b/src/main/resources/templates/single-sketch-template.html
@@ -9,7 +9,6 @@
 <body>
   <div id = "container">
     <div class = "navbar"> 
-		<h1 id="pageName">Logo goes here</h1>
 		<a href="javascript:void(0);" id="hamburger">
 						<i class = "fa fa-bars"></i>
 		</a>


### PR DESCRIPTION
This cleans up the single-sketch-template.html -- removed the "Logo goes here" filler text