### PR TITLE
after using hamburger nav height is fixed

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -339,7 +339,7 @@ h1{
    #myLinks{
        display:block;
        height:0px;
-	   transition:height 1s linear;
+	   transition:height .5s linear;
    }
    
    #myLinks a{
@@ -369,6 +369,7 @@ h1{
    }
 
 }
+
 
 
 

--- a/src/main/resources/static/js/stickyNav.js
+++ b/src/main/resources/static/js/stickyNav.js
@@ -24,3 +24,11 @@ function myFunction() {
     }
      
   }
+
+window.onresize = resetHeight;
+
+function resetHeight(){
+	if(window.matchMedia("(min-width: 567px)").matches){
+		ul.removeAttribute("style");
+	}
+}


### PR DESCRIPTION
Problem: After using hamburger icon in the nav menu, when the window was expanded back to the regular sticky nav, the links height was either 240px or 0px.  

I added an Javascript to remove the style/height attribute when the window was resized back to the menu with words. So now the menu items are the proper height after using the responsive(small screen) menu and resizing back to the large screen menu. 