### PR TITLE
Comments and add/delete boxes added to the single-sketch-templeate

### DIFF
--- a/src/main/java/org/wecancodeit/sketchflex/SketchFlexPopulator.java
+++ b/src/main/java/org/wecancodeit/sketchflex/SketchFlexPopulator.java
@@ -4,8 +4,10 @@ import javax.annotation.Resource;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.wecancodeit.sketchflex.models.Comment;
 import org.wecancodeit.sketchflex.models.Sketch;
 import org.wecancodeit.sketchflex.models.SketchDeck;
+import org.wecancodeit.sketchflex.repositories.CommentRepository;
 import org.wecancodeit.sketchflex.repositories.SketchDeckRepository;
 import org.wecancodeit.sketchflex.repositories.SketchRepository;
 
@@ -18,6 +20,9 @@ public class SketchFlexPopulator implements CommandLineRunner{
 	@Resource
 	private SketchDeckRepository sketchDeckRepo;
 	
+	@Resource
+	private CommentRepository commentRepo;
+	
 	@Override
 	public void run(String... args) throws Exception {
 		SketchDeck dinosaurs =new SketchDeck("Dinosaurs");
@@ -25,6 +30,10 @@ public class SketchFlexPopulator implements CommandLineRunner{
 		
 		Sketch tRex = new Sketch("T-Rex","/populator/t-rex.jpg",dinosaurs, "Rawr!");
 		sketchRepo.save(tRex);
+		Comment commentTRex1 = new Comment ("Picture of a t-rex!", tRex);
+		commentRepo.save(commentTRex1);
+		Comment commentTRex2 = new Comment ("Try and delete this note!!!!!", tRex);
+		commentRepo.save(commentTRex2);
 		
 		Sketch tric = new Sketch("Triceratops","/populator/triceratops.gif",dinosaurs);
 		sketchRepo.save(tric);

--- a/src/main/java/org/wecancodeit/sketchflex/controllers/CommentController.java
+++ b/src/main/java/org/wecancodeit/sketchflex/controllers/CommentController.java
@@ -1,0 +1,51 @@
+package org.wecancodeit.sketchflex.controllers;
+
+import java.util.Optional;
+
+import javax.annotation.Resource;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.wecancodeit.sketchflex.models.Sketch;
+import org.wecancodeit.sketchflex.models.Comment;
+import org.wecancodeit.sketchflex.repositories.CommentRepository;
+import org.wecancodeit.sketchflex.repositories.SketchRepository;
+
+@Controller
+public class CommentController {
+
+	@Resource
+	private SketchRepository sketchRepo;
+
+	@Resource
+	private CommentRepository commentRepo;
+
+	@RequestMapping("/add-comment")
+	public String addComment(String commentContent, String sketchName) {
+		Sketch sketch = sketchRepo.findByName(sketchName);
+		Comment newComment = commentRepo.findByContent(commentContent);
+		Long sketchId = 1L;
+		if (sketch != null) {
+			sketchId = sketch.getId();
+		}
+		if (newComment == null) {
+			newComment = new Comment(commentContent, sketch);
+			commentRepo.save(newComment);
+		}
+		return "redirect:/sketch?id=" + sketchId;
+	}
+
+	@RequestMapping("/delete-comment")
+	public String deleteSketchCommentById(Long commentId) {
+		Optional<Comment> comment = commentRepo.findById(commentId);
+		Long sketchId = 1L;
+		if (comment.isPresent()) {
+			Comment deleteComment = comment.get();
+			if (deleteComment.getSketch() != null) {
+				sketchId = deleteComment.getSketch().getId();
+			}
+			commentRepo.delete(deleteComment);
+		}
+		return "redirect:/sketch?id=" + sketchId;
+	}
+}

--- a/src/main/java/org/wecancodeit/sketchflex/models/Comment.java
+++ b/src/main/java/org/wecancodeit/sketchflex/models/Comment.java
@@ -1,0 +1,66 @@
+package org.wecancodeit.sketchflex.models;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Comment {
+	
+	@Id
+	@GeneratedValue
+	private Long id;
+	@Lob
+	private String content;
+	@ManyToOne
+	private Sketch sketch;
+	
+	public Long getId() {
+		return id;
+	}
+	
+	public String getContent() {
+		return content;
+	}
+	
+	public Sketch getSketch() {
+		return sketch;
+	}
+	
+	protected Comment() {
+	 //Why???	
+	}
+	
+	public Comment(String content, Sketch sketch) {
+		this.content = content;
+		this.sketch = sketch;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Comment other = (Comment) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+
+}

--- a/src/main/java/org/wecancodeit/sketchflex/models/Sketch.java
+++ b/src/main/java/org/wecancodeit/sketchflex/models/Sketch.java
@@ -1,10 +1,12 @@
 package org.wecancodeit.sketchflex.models;
 
+import java.util.Collection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import com.google.gson.annotations.Expose;
 
@@ -27,6 +29,9 @@ public class Sketch {
 	@Lob
 	@Expose
 	private String note;
+	
+	@OneToMany(mappedBy = "sketch")
+	private Collection<Comment> comments;
 
 	protected Sketch() {
 		// WHYYYYY????????
@@ -77,6 +82,10 @@ public class Sketch {
 
 	public String getNote() {
 		return note;
+	}
+	
+	public Collection<Comment> getComments() {
+		return comments;
 	}
 
 	public void changeName(String newName) {

--- a/src/main/java/org/wecancodeit/sketchflex/repositories/CommentRepository.java
+++ b/src/main/java/org/wecancodeit/sketchflex/repositories/CommentRepository.java
@@ -1,0 +1,10 @@
+package org.wecancodeit.sketchflex.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.wecancodeit.sketchflex.models.Comment;
+
+public interface CommentRepository extends CrudRepository<Comment, Long> {
+	
+	Comment findByContent(String content);
+
+}

--- a/src/main/resources/templates/single-sketch-template.html
+++ b/src/main/resources/templates/single-sketch-template.html
@@ -27,6 +27,26 @@
 			<div class="name-and-image">
 				<div class="next-button"><img id="image" th:src="@{${sketch.imageLocation}}"></div>
 				<input id="note" type="text" name="sketchNote" th:value="${sketch.note}"></input>
+				
+				<div th:each = "comment: ${sketch.comments}">
+					<p th:text = "${comment.content}"></p>
+					<form method = "POST">
+						<div>
+							<input type = "hidden" name = "commentId" th:value = "${comment.id}"/>
+							<button th:formaction="@{delete-comment}">Delete Comment</button>
+						</div>
+					</form>					
+				</div>
+				<form id = "add-comment" method="POST">
+					<div id = "comment-box-div">
+						<label>Enter New Comment:</label>
+						<textarea id = "comment-box" type="text" name = "commentContent" placeholder = "comment"></textarea>
+						<input type="hidden" name="sketchName" th:value = "${sketch.name}"/>
+					</div>
+				<div>
+					<button th:formaction="@{add-comment}" >Submit</button>
+				</div>
+				</form>
 			</div>
 	</section>
 	

--- a/src/test/java/org/wecancodeit/sketchflex/controllers/CommentControllerTest.java
+++ b/src/test/java/org/wecancodeit/sketchflex/controllers/CommentControllerTest.java
@@ -1,0 +1,44 @@
+package org.wecancodeit.sketchflex.controllers;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.wecancodeit.sketchflex.models.Sketch;
+import org.wecancodeit.sketchflex.models.Comment;
+import org.wecancodeit.sketchflex.repositories.CommentRepository;
+import org.wecancodeit.sketchflex.repositories.SketchRepository;
+
+public class CommentControllerTest {
+
+	@InjectMocks
+	private CommentController underTest;
+	
+	@Mock
+	private SketchRepository sketchRepo;
+	
+	@Mock
+	private CommentRepository commentRepo;
+	
+	@Mock
+	private Comment comment;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+	}
+	
+	@Test
+	public void shouldAddAdditionalCommentToSketch() {
+		String sketchName = "sketch name";
+		Sketch newSketch = sketchRepo.findByName(sketchName);
+		String commentContent = "new comment";
+		underTest.addComment(commentContent, sketchName);
+		Comment newComment = new Comment(commentContent, newSketch);
+		when(commentRepo.save(newComment)).thenReturn(newComment);
+	}
+	
+}


### PR DESCRIPTION
Added Comments, Comment Repo, ability to see/add/delete comments on the single-sketch view.

It's not pretty (yet) but it's in this branch. -- Still need to keep the comments from jumping to different sketches. 

Currently the comments for tRex will stay on the page if you move to the triceratops 