### PR TITLE
Reorder sketches

### DIFF
--- a/src/main/java/org/wecancodeit/sketchflex/SketchFlexPopulator.java
+++ b/src/main/java/org/wecancodeit/sketchflex/SketchFlexPopulator.java
@@ -38,17 +38,6 @@ public class SketchFlexPopulator implements CommandLineRunner{
 		Sketch tric = new Sketch("Triceratops","/populator/triceratops.gif",dinosaurs);
 		sketchRepo.save(tric);
 		
-//		System.out.println("tRex: "+sketchRepo.findByName("T-Rex").getOrder());
-//		System.out.println("tric: "+sketchRepo.findByName("Triceratops").getOrder());
-//		tRex.setOrder(sketchRepo.findByName("Triceratops").getOrder());
-//		tric.setOrder(sketchRepo.findByName("T-Rex").getOrder());
-//		sketchRepo.save(tRex);
-//		sketchRepo.save(tric);
-//		System.out.println("tRex: "+sketchRepo.findByName("T-Rex").getOrder());
-//		System.out.println("tric: "+sketchRepo.findByName("Triceratops").getOrder());
-		
-		
-		
 		Sketch raptor = new Sketch("Velociraptor","/populator/raptor.jpg",dinosaurs);
 		sketchRepo.save(raptor);
 		

--- a/src/main/java/org/wecancodeit/sketchflex/SketchFlexPopulator.java
+++ b/src/main/java/org/wecancodeit/sketchflex/SketchFlexPopulator.java
@@ -38,6 +38,17 @@ public class SketchFlexPopulator implements CommandLineRunner{
 		Sketch tric = new Sketch("Triceratops","/populator/triceratops.gif",dinosaurs);
 		sketchRepo.save(tric);
 		
+//		System.out.println("tRex: "+sketchRepo.findByName("T-Rex").getOrder());
+//		System.out.println("tric: "+sketchRepo.findByName("Triceratops").getOrder());
+//		tRex.setOrder(sketchRepo.findByName("Triceratops").getOrder());
+//		tric.setOrder(sketchRepo.findByName("T-Rex").getOrder());
+//		sketchRepo.save(tRex);
+//		sketchRepo.save(tric);
+//		System.out.println("tRex: "+sketchRepo.findByName("T-Rex").getOrder());
+//		System.out.println("tric: "+sketchRepo.findByName("Triceratops").getOrder());
+		
+		
+		
 		Sketch raptor = new Sketch("Velociraptor","/populator/raptor.jpg",dinosaurs);
 		sketchRepo.save(raptor);
 		

--- a/src/main/java/org/wecancodeit/sketchflex/controllers/SketchDeckController.java
+++ b/src/main/java/org/wecancodeit/sketchflex/controllers/SketchDeckController.java
@@ -6,11 +6,15 @@ import javax.annotation.Resource;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.wecancodeit.sketchflex.exceptions.SketchDeckNotFoundException;
+import org.wecancodeit.sketchflex.models.Sketch;
 import org.wecancodeit.sketchflex.models.SketchDeck;
 import org.wecancodeit.sketchflex.repositories.SketchDeckRepository;
+import org.wecancodeit.sketchflex.repositories.SketchRepository;
 
 
 @Controller
@@ -18,7 +22,9 @@ public class SketchDeckController {
 	
 	@Resource
 	SketchDeckRepository sketchDeckRepo;
-
+	
+	@Resource
+	SketchRepository sketchRepo;
 	
 	@RequestMapping("/sketchdeck")
 	public String findOneSketchDeck(@RequestParam(value = "id")Long id, Model model) throws SketchDeckNotFoundException{
@@ -44,6 +50,21 @@ public class SketchDeckController {
 	@RequestMapping("/home")
 	public String displayHome() {
 		return "index";
+	}
+	
+	@RequestMapping(path = "/{idOne}/reorder/{idTwo}", method = RequestMethod.POST)
+	public String reorderSketches(@PathVariable("idOne") Long idOne, @PathVariable("idTwo") Long idTwo, Model model) {
+		Sketch sketchOne = sketchRepo.findById(idOne).get();
+		Sketch sketchTwo = sketchRepo.findById(idTwo).get();
+		Long sketchOneOrder = sketchOne.getOrder();
+		Long sketchTwoOrder = sketchTwo.getOrder();
+		sketchOne.setOrder(sketchTwoOrder);
+		sketchTwo.setOrder(sketchOneOrder);
+		sketchRepo.save(sketchOne);
+		sketchRepo.save(sketchTwo);
+		SketchDeck sketchDeck = sketchOne.getSketchDeck();
+		model.addAttribute("sketches",sketchDeck.getSketches());
+		return "partials/sketchDeck-order-changed";
 	}
 
 }

--- a/src/main/java/org/wecancodeit/sketchflex/models/Sketch.java
+++ b/src/main/java/org/wecancodeit/sketchflex/models/Sketch.java
@@ -31,6 +31,8 @@ public class Sketch {
 
 	@OneToMany(mappedBy = "sketch")
 	private Collection<Comment> comments;
+	
+	private Long deckOrder;
 
 	public Long getId() {
 		return id;
@@ -51,6 +53,16 @@ public class Sketch {
 	public String getNote() {
 		return note;
 	}
+	
+	public Long getOrder() {
+		Long value;
+		if (deckOrder == null) {
+			value = id;
+		}else {
+			value = deckOrder;
+		}
+		return value;
+	}
 
 	public Collection<Comment> getComments() {
 		return comments;
@@ -66,6 +78,10 @@ public class Sketch {
 
 	public void setNote(String note) {
 		this.note = note;
+	}
+	
+	public void setOrder(Long order) {
+		this.deckOrder = order;
 	}
 
 	public void moveDeck(SketchDeck newSketchDeck) {

--- a/src/main/java/org/wecancodeit/sketchflex/models/SketchDeck.java
+++ b/src/main/java/org/wecancodeit/sketchflex/models/SketchDeck.java
@@ -1,5 +1,6 @@
 package org.wecancodeit.sketchflex.models;
 
+import java.util.Comparator;
 import java.util.List;
 
 import javax.persistence.Entity;
@@ -34,6 +35,7 @@ public class SketchDeck {
 	}
 
 	public List<Sketch> getSketches() {
+		sketches.sort(Comparator.comparing(sketch->sketch.getOrder()));
 		return sketches;
 	}
 

--- a/src/main/resources/static/js/reorderSketches.js
+++ b/src/main/resources/static/js/reorderSketches.js
@@ -1,0 +1,57 @@
+/**
+Add a reorder menu to the end of each "name-and-image" element
+ */
+var eachSketch = document.getElementsByClassName("name-and-image");
+
+for(i=0; i < eachSketch.length; i++){
+	var pButton = document.createElement("button");
+	pButton.innerHTML = "<";
+	pButton.setAttribute("id", "p"+i);
+	
+	var nButton = document.createElement("button");
+	nButton.innerHTML = ">";
+	nButton.setAttribute("id", "n"+i);
+	
+	var menu = document.createElement("div");
+	menu.setAttribute("class", "reorderMenu");
+	
+	eachSketch[i].appendChild(menu);
+	menu.appendChild(pButton);
+	var text = document.createElement("a");
+	text.setAttribute("class", "reorderText");
+	text.innerHTML = "Reorder Sketch";
+	menu.appendChild(text);
+	menu.appendChild(nButton);
+	
+	pButton.addEventListener("click", previous);
+	nButton.addEventListener("click", next);
+}
+
+function previous(sketch){
+	console.log(sketch.target)
+}
+
+function next(sketch){
+	console.log(sketch.target)
+}
+
+/**
+Disable the link to single sketch view when reorder menu is hovered.
+ */
+var menus = document.getElementsByClassName("reorderMenu");
+for(i=0; i<menus.length; i++){
+	menus[i].addEventListener("mouseover", dontLink);
+	menus[i].addEventListener("mouseout", link);
+}
+
+function dontLink(){
+	for(i=0; i < eachSketch.length; i++){
+		eachSketch[i].setAttribute("onClick", "return false");
+	}
+}
+function link(){
+	for(i=0; i < eachSketch.length; i++){
+		eachSketch[i].setAttribute("onClick", "return true");
+	}
+}
+

--- a/src/main/resources/static/js/reorderSketches.js
+++ b/src/main/resources/static/js/reorderSketches.js
@@ -1,57 +1,90 @@
 /**
 Add a reorder menu to the end of each "name-and-image" element
  */
-var eachSketch = document.getElementsByClassName("name-and-image");
+window.onload = function(){
+	drawButtons();
+}
+function drawButtons(){
+	var eachSketch = document.getElementsByClassName("name-and-image");
+	for(i=0; i < eachSketch.length; i++){
+		var pButton = document.createElement("button");
+		pButton.innerHTML = "<";
+		pButton.setAttribute("id", i);
+	
+		var nButton = document.createElement("button");
+		nButton.innerHTML = ">";
+		nButton.setAttribute("id", i);
+	
+		var menu = document.createElement("div");
+		menu.setAttribute("class", "reorderMenu");
+	
+		eachSketch[i].appendChild(menu);
+		menu.appendChild(pButton);
+		var text = document.createElement("a");
+		text.setAttribute("class", "reorderText");
+		text.innerHTML = "Reorder Sketch";
+		menu.appendChild(text);
+		menu.appendChild(nButton);
+	
+		pButton.addEventListener("click", previous);
+		nButton.addEventListener("click", next);
+	}
+	/**
+	Disable the link to single sketch view when reorder menu is hovered.
+	 */
+	var menus = document.getElementsByClassName("reorderMenu");
+	for(i=0; i<menus.length; i++){
+		menus[i].addEventListener("mouseover", dontLink);
+		menus[i].addEventListener("mouseout", link);
+	}
 
-for(i=0; i < eachSketch.length; i++){
-	var pButton = document.createElement("button");
-	pButton.innerHTML = "<";
-	pButton.setAttribute("id", "p"+i);
-	
-	var nButton = document.createElement("button");
-	nButton.innerHTML = ">";
-	nButton.setAttribute("id", "n"+i);
-	
-	var menu = document.createElement("div");
-	menu.setAttribute("class", "reorderMenu");
-	
-	eachSketch[i].appendChild(menu);
-	menu.appendChild(pButton);
-	var text = document.createElement("a");
-	text.setAttribute("class", "reorderText");
-	text.innerHTML = "Reorder Sketch";
-	menu.appendChild(text);
-	menu.appendChild(nButton);
-	
-	pButton.addEventListener("click", previous);
-	nButton.addEventListener("click", next);
+	function dontLink(){
+		for(i=0; i < eachSketch.length; i++){
+			eachSketch[i].setAttribute("onClick", "return false");
+		}
+	}
+	function link(){
+		for(i=0; i < eachSketch.length; i++){
+			eachSketch[i].setAttribute("onClick", "return true");
+		}
+	}
 }
 
 function previous(sketch){
-	console.log(sketch.target)
+	if(sketch.target.id > 0){
+		var idOne = sketch.target.parentElement.parentElement.href;
+		idOne = idOne.split("=")[1];
+		var idTwo = sketch.target.id - 1;
+		idTwo = document.getElementById(idTwo).parentElement.parentElement.href;
+		idTwo = idTwo.split("=")[1];
+		submitOrder(idOne, idTwo);
+	}
 }
 
 function next(sketch){
-	console.log(sketch.target)
-}
-
-/**
-Disable the link to single sketch view when reorder menu is hovered.
- */
-var menus = document.getElementsByClassName("reorderMenu");
-for(i=0; i<menus.length; i++){
-	menus[i].addEventListener("mouseover", dontLink);
-	menus[i].addEventListener("mouseout", link);
-}
-
-function dontLink(){
-	for(i=0; i < eachSketch.length; i++){
-		eachSketch[i].setAttribute("onClick", "return false");
+	var idOne = sketch.target.id;
+	var idTwo = parseInt(idOne, 10) + 1;
+	idTwo = document.getElementById(idTwo);
+	if(idTwo != null){
+		idOne = sketch.target.parentElement.parentElement.href;
+		idOne = idOne.split("=")[1];
+		idTwo = idTwo.parentElement.parentElement.href;
+		idTwo = idTwo.split("=")[1];
+		submitOrder(idOne, idTwo);
 	}
 }
-function link(){
-	for(i=0; i < eachSketch.length; i++){
-		eachSketch[i].setAttribute("onClick", "return true");
+
+var sketchList = document.getElementsByClassName("sketches-list")[0];
+const xhr = new XMLHttpRequest();
+xhr.onreadystatechange = function() {
+	if(xhr.readyState === 4 && xhr.status === 200){
+		const res = xhr.response;
+		sketchList.innerHTML = res;
+		drawButtons();
 	}
+}
+function submitOrder(idOne, idTwo){
+	xhr.open("POST", idOne + "/reorder/" + idTwo, true);
+	xhr.send();
 }
 

--- a/src/main/resources/templates/partials/sketchDeck-order-changed.html
+++ b/src/main/resources/templates/partials/sketchDeck-order-changed.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="ISO-8859-1">
+<title>Insert title here</title>
+</head>
+<body>
+	<a class="name-and-image" th:each="sketch:${sketches}" th:href="@{/sketch(id=${sketch.id})}">
+		<h2 class="sketch-name" th:text="${sketch.name}"></h2>
+		<img th:src="@{${sketch.imageLocation}}">
+	</a>
+</body>
+</html>

--- a/src/main/resources/templates/single-sketchdeck-template.html
+++ b/src/main/resources/templates/single-sketchdeck-template.html
@@ -32,6 +32,7 @@
 			</ul>
 		</footer>
 	</div>
+	<script type="text/javascript" src="/js/reorderSketches.js"></script>
 	<script type="text/javascript" th:src="@{/js/stickyNav.js}"></script>
 </body>
 </html>

--- a/src/test/java/org/wecancodeit/sketchflex/controllers/SketchDeckControllerMockMVCTest.java
+++ b/src/test/java/org/wecancodeit/sketchflex/controllers/SketchDeckControllerMockMVCTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.wecancodeit.sketchflex.models.SketchDeck;
 import org.wecancodeit.sketchflex.repositories.SketchDeckRepository;
+import org.wecancodeit.sketchflex.repositories.SketchRepository;
 import org.wecancodeit.sketchflex.storage.StorageService;
 import org.wecancodeit.sketchflex.controllers.SketchDeckController;
 

--- a/src/test/java/org/wecancodeit/sketchflex/controllers/SketchDeckControllerMockMVCTest.java
+++ b/src/test/java/org/wecancodeit/sketchflex/controllers/SketchDeckControllerMockMVCTest.java
@@ -41,6 +41,9 @@ public class SketchDeckControllerMockMVCTest {
 	
   @MockBean
   private SketchDeckRepository sketchDeckRepo;
+	
+  @MockBean
+  private SketchRepository sketchRepo;	
   
   @MockBean  //Tests failed without this even though it's not being tested...do not delete
   private StorageService storageService;


### PR DESCRIPTION
deckOrder field added to Sketch objects.
getSketches() method in SketchDeck object will return a list sorted by deckOrder.
deckOrder defaults to the Sketch id.

reorderSketches.js adds buttons to the single-sketchdeck-template. buttons run ajax request when clicked. 
SketchDeckController will switch the deckOrder of two sketches, return a partial template with the sketches in the new order, and the buttons are redrawn on the new partial template. 