### PR TITLE
removing gap from sketchdecks page mobile

### DIFF
--- a/src/main/resources/templates/all-sketchdecks-template.html
+++ b/src/main/resources/templates/all-sketchdecks-template.html
@@ -18,7 +18,6 @@
 		</div>
 		<div>
 			<h1>All SketchDecks</h1>
-		</div>
 		<section  class = "sketchdeck-list" >
 			<a class="name-and-image" th:each="sketchDeck:${sketchDecks}" th:href="@{/sketchdeck(id=${sketchDeck.id})}">
 				<h2 class="sketch-name" th:text="${sketchDeck.name}"></h2>
@@ -26,6 +25,7 @@
 				<div id="description" th:text="${sketchDeck.description}"></div>			
 			</a>
 		</section>
+		</div>
 		<footer>
             <p id="footerText">Copyright 2019 - We Can Code IT - Spring Cohort</p>     
         </footer>  


### PR DESCRIPTION
closing div tag was in wrong place on sketchdecks html causing a gap to
appear in mobile view